### PR TITLE
updating broken link to your blog

### DIFF
--- a/src/Contributing.md
+++ b/src/Contributing.md
@@ -6,4 +6,4 @@ This project is only as useful as we (the community) make it. Things will change
 
 I'm 100% sure that I have gotten some things wrong in this project. My hope is that by putting this together, we can get the ball rolling on creating more comprehensive documentation for attacking a Kubernetes cluster. The more we're able to document these attacks, the more easily we will be able to communicate the risk of an insecure cluster.
 
-Are you new to the security industry but you've found something about this project lacking? Contributing to open source projects is a fantastic way to [demonstrate your competence](https://grahamhelton.com/blog/certificationindustrialcomplex/) for future employers to see. Contributions that keep things up to date is always appreciated!
+Are you new to the security industry but you've found something about this project lacking? Contributing to open source projects is a fantastic way to [demonstrate your competence](https://grahamhelton.com/blog/the-certification-industrial-complex) for future employers to see. Contributions that keep things up to date is always appreciated!


### PR DESCRIPTION
Hey @grahamhelton, I was reading through the contribution page and noticed that your link was broken referencing your blog.

<img width="787" height="520" alt="image" src="https://github.com/user-attachments/assets/7a5bd132-546d-4379-8a78-c106733be04e" />

[This](https://grahamhelton.com/blog/the-certification-industrial-complex) seems to be the new/correct link so I figured I'd do a PR to fix it.

I more recently [came across this initiative](https://www.linkedin.com/posts/jasonwalker777_ive-completed-the-kubernetes-red-team-analyst-share-7409711189183758337-yJUO/) while researching for references [on a talk I gave this past weekend](https://speakers.southeastlinuxfest.org/southeast-linux-fest-2026/talk/PLJSWD/). While I haven't gone through it all yet, I'm super happy at least someone is working towards aggregating all this! (P.S. I included it in my slides 😁)
I'm hoping to, as time permits, help out as I can 🙂 